### PR TITLE
Updated Python CLI Service/Login Options

### DIFF
--- a/src/python/cdb/cdb_web_service/cli/addItemLogEntryCli.py
+++ b/src/python/cdb/cdb_web_service/cli/addItemLogEntryCli.py
@@ -5,12 +5,12 @@ Copyright (c) UChicago Argonne, LLC. All rights reserved.
 See LICENSE file.
 """
 from cdb.cdb_web_service.api.itemRestApi import ItemRestApi
-from cdbWebServiceCli import CdbWebServiceCli
+from cdbWebServiceSessionCli import CdbWebServiceSessionCli
 from cdb.common.exceptions.invalidRequest import InvalidRequest
 
-class addItemLogEntry(CdbWebServiceCli):
+class addItemLogEntry(CdbWebServiceSessionCli):
     def __init__(self):
-        CdbWebServiceCli.__init__(self)
+        CdbWebServiceSessionCli.__init__(self)
         self.addOption('', '--qr-id', dest='qrId', help='QrId of item to add log entry for')
         self.addOption('', '--item-id', dest='itemId', help='Item id of an item to add log entry for')
         self.addOption('', '--log-entry', dest='logEntry', help='Log entry text to add to the item with qrId specified.')
@@ -36,7 +36,7 @@ class addItemLogEntry(CdbWebServiceCli):
 
     def runCommand(self):
         self.parseArgs(usage="""
-    cdb-add-item-log-entry --qr-id=QRID --item-id=ITEMID
+    cdb-add-item-log-entry --qr-id=QRID|--item-id=ITEMID
         --log-entry=LOGENTRY
         --attachment=ATTACHMENT
 

--- a/src/python/cdb/cdb_web_service/cli/addItemPropertyValueCli.py
+++ b/src/python/cdb/cdb_web_service/cli/addItemPropertyValueCli.py
@@ -5,12 +5,12 @@ Copyright (c) UChicago Argonne, LLC. All rights reserved.
 See LICENSE file.
 """
 from cdb.cdb_web_service.api.itemRestApi import ItemRestApi
-from cdbWebServiceCli import CdbWebServiceCli
+from cdbWebServiceSessionCli import CdbWebServiceSessionCli
 from cdb.common.exceptions.invalidRequest import InvalidRequest
 
-class addItemPropertyValueCli(CdbWebServiceCli):
+class addItemPropertyValueCli(CdbWebServiceSessionCli):
     def __init__(self):
-        CdbWebServiceCli.__init__(self)
+        CdbWebServiceSessionCli.__init__(self)
         self.addOption('', '--item-id', dest='itemId', help='item id of item to add property value for')
         self.addOption('', '--property-type-name', dest='propertyTypeName', help='Property type name of the property to add to item')
         self.addOption('', '--value', dest='value', help='value of the newly added property')

--- a/src/python/cdb/cdb_web_service/cli/addLogAttachmentCli.py
+++ b/src/python/cdb/cdb_web_service/cli/addLogAttachmentCli.py
@@ -6,12 +6,12 @@ See LICENSE file.
 """
 from cdb.cdb_web_service.api.itemRestApi import ItemRestApi
 from cdb.cdb_web_service.api.logRestApi import LogRestApi
-from cdbWebServiceCli import CdbWebServiceCli
+from cdbWebServiceSessionCli import CdbWebServiceSessionCli
 from cdb.common.exceptions.invalidRequest import InvalidRequest
 
-class addItemLogAttachment(CdbWebServiceCli):
+class addItemLogAttachment(CdbWebServiceSessionCli):
     def __init__(self):
-        CdbWebServiceCli.__init__(self)
+        CdbWebServiceSessionCli.__init__(self)
         self.addOption('', '--log-id', dest='logId', help='Id of the log entry to add attachment for')
         self.addOption('', '--attachment', dest='attachment', help='Attachment to add to the log entry.')
         self.addOption('', '--attachment-description', dest='attachmentDescription', help='Attachment description')

--- a/src/python/cdb/cdb_web_service/cli/addPropertyMetadataToPropertyValueCli.py
+++ b/src/python/cdb/cdb_web_service/cli/addPropertyMetadataToPropertyValueCli.py
@@ -5,12 +5,12 @@ Copyright (c) UChicago Argonne, LLC. All rights reserved.
 See LICENSE file.
 """
 from cdb.cdb_web_service.api.propertyRestApi import PropertyRestApi
-from cdbWebServiceCli import CdbWebServiceCli
+from cdbWebServiceSessionCli import CdbWebServiceSessionCli
 from cdb.common.exceptions.invalidRequest import InvalidRequest
 
-class addPropertyMetadataToPropertyValueCli(CdbWebServiceCli):
+class addPropertyMetadataToPropertyValueCli(CdbWebServiceSessionCli):
     def __init__(self):
-        CdbWebServiceCli.__init__(self)
+        CdbWebServiceSessionCli.__init__(self)
         self.addOption('', '--property-value-id', dest='propertyValueId', help='Property value id of the property metadata is being added to')
         self.addOption('', '--metadata-dict', dest='metadataDict', help='Metadata dict with key value pairs for new metadata')
         self.addOption('', '--metadata-key', dest='metadataKey', help='Key of the metadata value being added')

--- a/src/python/cdb/cdb_web_service/cli/deleteItemPropertyValuesCli.py
+++ b/src/python/cdb/cdb_web_service/cli/deleteItemPropertyValuesCli.py
@@ -5,12 +5,12 @@ Copyright (c) UChicago Argonne, LLC. All rights reserved.
 See LICENSE file.
 """
 from cdb.cdb_web_service.api.itemRestApi import ItemRestApi
-from cdbWebServiceCli import CdbWebServiceCli
+from cdbWebServiceSessionCli import CdbWebServiceSessionCli
 from cdb.common.exceptions.invalidRequest import InvalidRequest
 
-class DeleteItemPropertyValueCli(CdbWebServiceCli):
+class DeleteItemPropertyValueCli(CdbWebServiceSessionCli):
     def __init__(self):
-        CdbWebServiceCli.__init__(self)
+        CdbWebServiceSessionCli.__init__(self)
         self.addOption('', '--item-id', dest='itemId', help='item id of item to add property value for')
         self.addOption('', '--property-type-name', dest='propertyTypeName', help='Property type name of the property to add to item')
 

--- a/src/python/cdb/cdb_web_service/cli/deleteLogCli.py
+++ b/src/python/cdb/cdb_web_service/cli/deleteLogCli.py
@@ -6,12 +6,12 @@ See LICENSE file.
 """
 
 from cdb.cdb_web_service.api.logRestApi import LogRestApi
-from cdbWebServiceCli import CdbWebServiceCli
+from cdbWebServiceSessionCli import CdbWebServiceSessionCli
 from cdb.common.exceptions.invalidRequest import InvalidRequest
 
-class DeleteLogCli(CdbWebServiceCli):
+class DeleteLogCli(CdbWebServiceSessionCli):
     def __init__(self):
-        CdbWebServiceCli.__init__(self)
+        CdbWebServiceSessionCli.__init__(self)
         self.addOption('', '--log-id', dest='logId', help='Id of the log entry to add attachment for')
 
     def checkArgs(self):

--- a/src/python/cdb/cdb_web_service/cli/loadLatticeDesignCli.py
+++ b/src/python/cdb/cdb_web_service/cli/loadLatticeDesignCli.py
@@ -7,14 +7,14 @@ See LICENSE file.
 
 
 import os
-from cdbWebServiceCli import CdbWebServiceCli
+from cdbWebServiceSessionCli import CdbWebServiceSessionCli
 from cdb.cdb_web_service.api.designRestApi import DesignRestApi
 from cdb.common.exceptions.invalidRequest import InvalidRequest
 from cdb.common.exceptions.invalidArgument import InvalidArgument
 
-class LoadLatticeDesignCli(CdbWebServiceCli):
+class LoadLatticeDesignCli(CdbWebServiceSessionCli):
     def __init__(self):
-        CdbWebServiceCli.__init__(self)
+        CdbWebServiceSessionCli.__init__(self)
         self.addOption('', '--csv-file', dest='csvFile', help='CSV file containing lattice design (required).')
         self.addOption('', '--name', dest='name', help='Lattice design name (required).')
         self.addOption('', '--description', dest='description', help='Lattice design description.')

--- a/src/python/cdb/cdb_web_service/cli/updateLogCli.py
+++ b/src/python/cdb/cdb_web_service/cli/updateLogCli.py
@@ -6,12 +6,12 @@ See LICENSE file.
 """
 
 from cdb.cdb_web_service.api.logRestApi import LogRestApi
-from cdbWebServiceCli import CdbWebServiceCli
+from cdbWebServiceSessionCli import CdbWebServiceSessionCli
 from cdb.common.exceptions.invalidRequest import InvalidRequest
 
-class UpdateLogCli(CdbWebServiceCli):
+class UpdateLogCli(CdbWebServiceSessionCli):
     def __init__(self):
-        CdbWebServiceCli.__init__(self)
+        CdbWebServiceSessionCli.__init__(self)
         self.addOption('', '--log-id', dest='logId', help='Id of the log entry to add attachment for')
         self.addOption('', '--text', dest='text', help='Text conatined in the log entry')
         self.addOption('', '--log-topic-name', dest='logTopicName', help='name of the log topic associated with log')

--- a/src/python/cdb/common/cli/cdbRestCli.py
+++ b/src/python/cdb/common/cli/cdbRestCli.py
@@ -20,9 +20,7 @@ class CdbRestCli(CdbCli):
         serviceGroup = 'Service Options'
         self.addOptionGroup(serviceGroup, None)
         # These will be set via env variables
-        self.addOptionToGroup(serviceGroup, '', '--service-host', dest='serviceHost', default=self.getDefaultServiceHost(), help='Service host (default: %s, can be set via CDB_SERVICE_HOST environment variable).' % self.getDefaultServiceHost())
-        self.addOptionToGroup(serviceGroup, '', '--service-port', dest='servicePort', default=self.getDefaultServicePort(), help='Service port (default: %s, can be set via CDB_SERVICE_PORT environment variable).' % self.getDefaultServicePort())
-        self.addOptionToGroup(serviceGroup, '', '--service-protocol', dest='serviceProtocol', default=self.getDefaultServiceProtocol(), help='Service protocol (default: %s, can be set via CDB_SERVICE_PROTOCOL environment variable).' % self.getDefaultServiceProtocol())
+        self.addOptionToGroup(serviceGroup, '', '--service-url', dest='serviceUrl', default=self.getDefaultServiceUrl(), help='Service URL (default: %s, can be set via CDB_SERVICE_URL environment variable).' % self.getDefaultServiceUrl())
 
         # SSL options, disabled for now.
         #self.addOptionToGroup(commonGroup, '', '--ssl-key', dest='sslKeyFile', help='SSL key file (needed if service requires peer verification, can be set via CDB_SSL_KEY_FILE environment variable).')
@@ -38,15 +36,17 @@ class CdbRestCli(CdbCli):
     def getDefaultServiceProtocol(self):
         return ConfigurationManager.getInstance().getServiceProtocol()
 
+    def getDefaultServiceUrl(self):
+        return ConfigurationManager.getInstance().getServiceUrl()
+
     def parseArgs(self, usage=None):
         CdbCli.parseArgs(self, usage)
         configManager = ConfigurationManager.getInstance()
-        self.serviceHost = self.options.serviceHost
-        configManager.setServiceHost(self.serviceHost)
-        self.servicePort = self.options.servicePort
-        configManager.setServicePort(self.servicePort)
-        self.serviceProtocol = self.options.serviceProtocol
-        configManager.setServiceProtocol(self.serviceProtocol)
+        self.serviceUrl = self.options.serviceUrl
+        configManager.setServiceUrl(self.serviceUrl)
+        self.serviceHost = configManager.getServiceHost()
+        self.servicePort = configManager.getServicePort()
+        self.serviceProtocol = configManager.getServiceProtocol()
 
         # SSL options, comment out for now
         #self.sslCaCertFile = self.options.sslCaCertFile

--- a/src/python/cdb/common/cli/cdbRestSessionCli.py
+++ b/src/python/cdb/common/cli/cdbRestSessionCli.py
@@ -7,37 +7,57 @@ See LICENSE file.
 
 
 from cdb.common.cli.cdbRestCli import CdbRestCli
+from cdb.common.utility.configurationManager import ConfigurationManager
 
 class CdbRestSessionCli(CdbRestCli):
     """ Base cdb session cli class. """
 
     def __init__(self, validArgCount=0):
         CdbRestCli.__init__(self, validArgCount)
-        self.username = None
-        self.password = None
 
         loginGroup = 'Login Options'
         self.addOptionGroup(loginGroup, None)
-        self.addOptionToGroup(loginGroup, '', '--login-username', dest='loginUsername', help='Login username.')
-        self.addOptionToGroup(loginGroup, '', '--login-password', dest='loginPassword', help='Login password.')
+        self.addOptionToGroup(loginGroup, '', '--username', dest='username', help='Login username.')
+        self.addOptionToGroup(loginGroup, '', '--password', dest='password', help='Login password.')
+        self.addOptionToGroup(loginGroup, '', '--login-file', dest='loginFile', help='Login file (can be set via CDB_LOGIN_FILE environment variable).')
 
     def parseArgs(self, usage=None):
         CdbRestCli.parseArgs(self, usage)
-        self.loginUsername = self.options.loginUsername
-        self.loginPassword = self.options.loginPassword
+        self.username = self.options.username
+        self.password = self.options.password
+        self.loginFile = self.options.loginFile
+        self.parseLoginFile()
         return (self.options, self.args)
 
-    def getLoginUsername(self):
-        return self.loginUsername
+    def getUsername(self):
+        return self.username
 
-    def getLoginPassword(self):
-        return self.loginPassword
+    def getPassword(self):
+        return self.password
+
+    def getLoginFile(self):
+        if not self.loginFile:
+            configManager = ConfigurationManager.getInstance()
+            self.loginFile = configManager.getLoginFile()
+        return self.loginFile
+
+    def parseLoginFile(self):
+        if self.getLoginFile() and not self.username and not self.password:
+            try:
+                # Assume form <username>|<password>
+                tokenList = open(self.loginFile).readline().split('|')
+                if len(tokenList) == 2:
+                    self.username = tokenList[0].strip()
+                    self.password = tokenList[1].strip()
+            except:
+                # Ignore invalid login file
+                pass
 
     def hasCredentials(self):
-        return (self.loginUsername != None and self.loginPassword != None)
+        return (self.username != None and self.password != None)
 
 #######################################################################
 # Testing
 
 if __name__ == '__main__':
-        pass
+    pass

--- a/src/python/cdb/common/db/impl/itemHandler.py
+++ b/src/python/cdb/common/db/impl/itemHandler.py
@@ -605,6 +605,16 @@ class ItemHandler(CdbDbEntityHandler):
                                enteredByUserId=None, isUserWriteable=None, isDynamic=None,
                                displayValue=None, targetValue=None, enteredOnDateTime = None, allowInternal=False):
         dbItemElement = self.getItemElementById(session, itemElementId)
+
+        dbPropertyType = self.propertyTypeHandler.getPropertyTypeByName(session, propertyTypeName)
+        dbItemElementProperties = self.propertyValueHandler.getItemElementProperties(session, itemElementId, propertyTypeName)
+
+        # Verify that we are not adding the same property again
+        for dbItemElementProperty in dbItemElementProperties:
+            dbPropertyValue = dbItemElementProperty.propertyValue
+            if dbPropertyValue.tag == tag and dbPropertyValue.value == value and dbPropertyValue.units == units and dbPropertyValue.description == description:
+                raise ObjectAlreadyExists('There is already identical property of type %s for item element id %s.' % (propertyTypeName, itemElementId))
+
         self.permissionHandler.verifyPermissionsForWriteToItemElement(session, enteredByUserId, dbItemElementObject=dbItemElement)
         dbPropertyValue = self.propertyValueHandler.createPropertyValue(session, propertyTypeName, tag, value, units, description, enteredByUserId, isUserWriteable, isDynamic, displayValue,targetValue, enteredOnDateTime, allowInternal)
 


### PR DESCRIPTION
This PR contains the following changes:
  - replace python CLI protocol/host/port with a single service url option
  - add python CLI login file option 
  - prevent adding duplicate properties to item elements