### PR TITLE
Path fix in cdb_create_db.sh to point to deploy config in /etc

### DIFF
--- a/sbin/cdb_create_db.sh
+++ b/sbin/cdb_create_db.sh
@@ -48,7 +48,7 @@ echo "Using DB name: $CDB_DB_NAME"
 
 # Look for deployment file in etc directory, and use it to override
 # default entries
-deployConfigFile=$CDB_ROOT_DIR/etc/${CDB_DB_NAME}.deploy.conf
+deployConfigFile=$CDB_INSTALL_DIR/etc/${CDB_DB_NAME}.deploy.conf
 if [ -f $deployConfigFile ]; then
     echo "Using deployment config file: $deployConfigFile"
     . $deployConfigFile


### PR DESCRIPTION
I found my docker container wasn't updating the db as expected when I ran "make clean-db", because this file was pointing to the wrong location for the deployment config file.