### PR TITLE
More robust way to get `_HOST_ARCH` in bash scripts

### DIFF
--- a/bin/cdb-ant
+++ b/bin/cdb-ant
@@ -15,7 +15,7 @@ if [ -z $CDB_ROOT_DIR ]; then
     source $setupFile
 fi
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 export JAVA_HOME=$CDB_SUPPORT_DIR/java/$CDB_HOST_ARCH
 export ANT_HOME=$CDB_SUPPORT_DIR/ant
 export PATH=$ANT_HOME/bin:$PATH

--- a/sbin/cdb_configure_web_portal.sh
+++ b/sbin/cdb_configure_web_portal.sh
@@ -41,7 +41,7 @@ else
     echo "Deployment config file $deployConfigFile not found, using defaults"
 fi
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 GLASSFISH_DIR=$CDB_SUPPORT_DIR/payara/$CDB_HOST_ARCH
 JAVA_HOME=$CDB_SUPPORT_DIR/java/$CDB_HOST_ARCH
 

--- a/sbin/cdb_deploy_mysqld.sh
+++ b/sbin/cdb_deploy_mysqld.sh
@@ -42,7 +42,7 @@ else
     echo "Deployment config file $deployConfigFile not found, using defaults"
 fi
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 CDB_SHORT_HOSTNAME=`hostname -s`
 CDB_SUPPORT_DIR=${CDB_SUPPORT_DIR:=$CDB_INSTALL_DIR/support-$CDB_SHORT_HOSTNAME}
 CDB_ETC_DIR=${CDB_INSTALL_DIR}/etc

--- a/sbin/cdb_deploy_web_portal.sh
+++ b/sbin/cdb_deploy_web_portal.sh
@@ -42,7 +42,7 @@ else
     echo "Deployment config file $deployConfigFile not found, using defaults"
 fi
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 CDB_CONTEXT_ROOT=${CDB_CONTEXT_ROOT:=cdb}
 CDB_PERM_CONTEXT_ROOT_URL=${CDB_PERM_CONTEXT_ROOT_URL:=http://localhost:8080/cdb}
 CDB_DATA_DIR=${CDB_DATA_DIR:=/cdb}

--- a/sbin/cdb_deploy_web_service.sh
+++ b/sbin/cdb_deploy_web_service.sh
@@ -43,7 +43,7 @@ else
     echo "Deployment config file $deployConfigFile not found, using defaults"
 fi
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 CDB_CONTEXT_ROOT=${CDB_CONTEXT_ROOT:=cdb}
 CDB_DATA_DIR=${CDB_DATA_DIR:=/cdb}
 CDB_ETC_DIR=${CDB_INSTALL_DIR}/etc

--- a/sbin/cdb_unconfigure_web_portal.sh
+++ b/sbin/cdb_unconfigure_web_portal.sh
@@ -43,7 +43,7 @@ else
     echo "Deployment config file $deployConfigFile not found, using defaults"
 fi
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 GLASSFISH_DIR=$CDB_SUPPORT_DIR/payara/$CDB_HOST_ARCH
 JAVA_HOME=$CDB_SUPPORT_DIR/java/$CDB_HOST_ARCH
 

--- a/sbin/cdb_undeploy_web_portal.sh
+++ b/sbin/cdb_undeploy_web_portal.sh
@@ -44,7 +44,7 @@ else
 fi
 
 CDB_DOMAIN_NAME="production"
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 CDB_CONTEXT_ROOT=${CDB_CONTEXT_ROOT:=cdb}
 GLASSFISH_DIR=$CDB_SUPPORT_DIR/payara/$CDB_HOST_ARCH
 CDB_APP_DIR=$GLASSFISH_DIR/glassfish/domains/$CDB_DOMAIN_NAME/applications/$CDB_CONTEXT_ROOT

--- a/sbin/cdb_undeploy_web_service.sh
+++ b/sbin/cdb_undeploy_web_service.sh
@@ -43,7 +43,7 @@ else
     echo "Deployment config file $deployConfigFile not found, using defaults"
 fi
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 CDB_CONTEXT_ROOT=${CDB_CONTEXT_ROOT:=cdb}
 CDB_DATA_DIR=${CDB_DATA_DIR:=/cdb}
 CDB_ETC_DIR=${CDB_INSTALL_DIR}/etc

--- a/setup.sh
+++ b/setup.sh
@@ -55,7 +55,7 @@ if [ -z $CDB_VAR_DIR ]; then
 fi
 
 # Establish machine architecture and host name
-CDB_HOST_ARCH="`uname | tr '[:upper:]' '[:lower:]'`-`uname -m`"
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 CDB_SHORT_HOSTNAME=`hostname -s`
 
 # Check support setup

--- a/support/bin/build_cherrypy.sh
+++ b/support/bin/build_cherrypy.sh
@@ -6,7 +6,7 @@
 
 # Need to update pypi Download URL manually upon version update
 CHERRY_PY_VERSION=8.1.2
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/build_mysql.sh
+++ b/support/bin/build_mysql.sh
@@ -6,7 +6,7 @@
 
 MYSQL_VERSION=5.6.37
 MYSQL_TGZ_FILE=mysql-$MYSQL_VERSION.tar.gz
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/build_mysql_python.sh
+++ b/support/bin/build_mysql_python.sh
@@ -6,7 +6,7 @@
 
 # Need to update pypi Download URL manually upon version update
 MYSQL_PYTHON_VERSION=1.2.5
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/build_python.sh
+++ b/support/bin/build_python.sh
@@ -5,7 +5,7 @@
 
 
 PYTHON_VERSION=2.7.16
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/build_sqlalchemy.sh
+++ b/support/bin/build_sqlalchemy.sh
@@ -6,7 +6,7 @@
 
 # Need to update pypi Download URL manually upon version update
 SQL_ALCHEMY_VERSION=0.9.8
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/build_suds.sh
+++ b/support/bin/build_suds.sh
@@ -6,7 +6,7 @@
 
 # Need to update pypi Download URL manually upon version update
 SUDS_VERSION=0.4
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/install_anaconda.sh
+++ b/support/bin/install_anaconda.sh
@@ -5,7 +5,7 @@
 
 ANACONDA_VERSION=2020.02
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/install_click.sh
+++ b/support/bin/install_click.sh
@@ -4,7 +4,7 @@
 # See LICENSE file.
 
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/install_glassfish.sh
+++ b/support/bin/install_glassfish.sh
@@ -5,7 +5,7 @@
 
 # Usage install_glassfish.sh [Install_DIR] [CONFIGURE 0/1]
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 CDB_HOSTNAME=`hostname -f`
 PAYARA_VERSION=5.192
 PAYARA_ZIP_FILE=payara-$PAYARA_VERSION.zip

--- a/support/bin/install_java.sh
+++ b/support/bin/install_java.sh
@@ -6,7 +6,7 @@
 JAVA_VERSION=11+28
 JDK_VERSION=jdk11
 
-CMS_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CMS_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/install_netbeans.sh
+++ b/support/bin/install_netbeans.sh
@@ -3,7 +3,7 @@
 # Copyright (c) UChicago Argonne, LLC. All rights reserved.
 # See LICENSE file.
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 CDB_HOSTNAME=`hostname -f`
 
 NETBEANS_VERSION=11.0

--- a/support/bin/install_pip.sh
+++ b/support/bin/install_pip.sh
@@ -4,7 +4,7 @@
 # See LICENSE file.
 
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/install_python_ldap.sh
+++ b/support/bin/install_python_ldap.sh
@@ -4,7 +4,7 @@
 # See LICENSE file.
 
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/install_routes.sh
+++ b/support/bin/install_routes.sh
@@ -4,7 +4,7 @@
 # See LICENSE file.
 
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/install_setuptools.sh
+++ b/support/bin/install_setuptools.sh
@@ -4,7 +4,7 @@
 # See LICENSE file.
 
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/install_sphinx.sh
+++ b/support/bin/install_sphinx.sh
@@ -4,7 +4,7 @@
 # See LICENSE file.
 
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`

--- a/support/bin/install_twine.sh
+++ b/support/bin/install_twine.sh
@@ -4,7 +4,7 @@
 # See LICENSE file.
 
 
-CDB_HOST_ARCH=`uname | tr [A-Z] [a-z]`-`uname -m`
+CDB_HOST_ARCH=$(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
 
 currentDir=`pwd`
 cd `dirname $0`/.. && topDir=`pwd`


### PR DESCRIPTION
Hi @iTerminate 

Sorry for the previous pull request.

If a directory contains specific files, `tr [A-Z] [a-b]` could be unpredictable. That command does return "no value", so the `*_HOST_ARCH` could be `-x86_64`. 

This pull request which replaced all `uname` related command to more robust one . Please look at the following examples:

```bash
tr_test$ echo `uname | tr [A-Z] [a-z]`-`uname -m`
linux-x86_64

tr_test$ ls -lta
total 8
drwxr-xr-x 2 jhlee jhlee 4096 Jul 10 17:10 .
drwxr-xr-x 7 jhlee jhlee 4096 Jul 10 17:10 ..

tr_test$ echo $(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
linux-x86_64

tr_test$ touch a A B
tr_test$ ls
a  A  B


tr_test$ echo `uname | tr [A-Z] [a-z]`-`uname -m`
tr: extra operand ‘a’
Try 'tr --help' for more information.
-x86_64
tr_test$ echo $(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
linux-x86_64

tr_test$ rm B
tr_test$ touch b
tr_test$ echo $(uname -sm | tr -s '[:upper:][:blank:]' '[:lower:][\-]')
linux-x86_64

tr_test$ echo `uname | tr [A-Z] [a-z]`-`uname -m`
tr: extra operand ‘b’
Try 'tr --help' for more information.
-x86_64
```

And let me know what you think. 

BTW, why `install_java.sh` has `CMD_HOST_ARCH` instead of `CDB_HOST_ARCH`?  

https://github.com/AdvancedPhotonSource/ComponentDB/blob/7198830a915992c96b5e4b430a531b42b6a505f7/support/bin/install_java.sh#L9-L17
 