### PR TITLE
fixed [: =: unary operator expected

### DIFF
--- a/sbin/cdb_create_configuration.sh
+++ b/sbin/cdb_create_configuration.sh
@@ -138,7 +138,7 @@ fi
 if [ ! -z $userLdapServerDnFormat ]; then
 	CDB_LDAP_AUTH_DN_FORMAT=$userLdapServerDnFormat
 fi
-if [ $ldapLookup == 'y' ]; then
+if [[ $ldapLookup == 'y' ]]; then
 	if [ ! -z $userLdapLookupFilter ]; then
 		CDB_LDAP_LOOKUP_FILTER="'$userLdapLookupFilter'"
 	elif [ ! -z $CDB_LDAP_LOOKUP_FILTER ]; then


### PR DESCRIPTION
Fixed the following message

```bash
./sbin/cdb_create_configuration.sh: line 141: [: ==: unary operator expected
```
with the bash way, because the shebang is bash. If one would like to use `not bash way`. We can use 

```bash 
if [ "$ldapLookup" == "y"]; then
```

 
Please let me know what you think.
