### PR TITLE
fix syntax error in travelerInstanceMoveDialog.xhtml

### DIFF
--- a/tools/developer_tools/cdb_plugins/plugins/traveler/xhtml/support/travelerInstanceMoveDialog.xhtml
+++ b/tools/developer_tools/cdb_plugins/plugins/traveler/xhtml/support/travelerInstanceMoveDialog.xhtml
@@ -19,7 +19,7 @@ See LICENSE file.
         <p:outputPanel id="travelerInstanceMoveDialogOutputPanel"
                        rendered="#{itemTravelerDomainInventoryController.renderMoveTravelerContents}">
             <ui:include src="../../../../item/private/itemSelectDataTable.xhtml">
-                <ui:param name="viewName" value="travelerInstanceMoveDialog"
+                <ui:param name="viewName" value="travelerInstanceMoveDialog" />
                 <ui:param name="updateTarget" value="travelerInstanceMoveDialogOutputPanel" /> 
                 <ui:param name="selectionValue" value="#{itemTravelerDomainInventoryController.inventoryItemToMoveCurrentTraveler}" />
                 <ui:param name="selectionTarget" value="#{itemTravelerDomainInventoryController.inventoryItemToMoveCurrentTraveler}" />


### PR DESCRIPTION
I added a ui:param to this file but originally forgot the closing bracket.  It didn't get checked in with my last update because I didn't run save_plugin.