### PR TITLE
fix the non-interger comparsion about Python argument

### DIFF
--- a/tools/developer_tools/cdb_plugins/update_plugin_generated_files.py
+++ b/tools/developer_tools/cdb_plugins/update_plugin_generated_files.py
@@ -23,7 +23,7 @@ plugin_manager = PluginManager(cdb_db_name, use_default_storage_directory=True)
 
 update_configuration = False
 if sys.argv.__len__() == 3:
-    input_update_configuration = sys.argv[2]
+    input_update_configuration = int(sys.argv[2])
     if input_update_configuration is not None:
         if input_update_configuration == 1:
             update_configuration = True


### PR DESCRIPTION
Hi @iTerminate 

According to the input argument comment at 
https://github.com/AdvancedPhotonSource/ComponentDB/blob/3ff7e945e722783a30392095d9c177e60627b79d/tools/developer_tools/cdb_plugins/update_plugin_generated_files.py#L11

This request can handle two different input arguments (0 or 1) properly to be used at 
https://github.com/AdvancedPhotonSource/ComponentDB/blob/3ff7e945e722783a30392095d9c177e60627b79d/tools/developer_tools/cdb_plugins/update_plugin_generated_files.py#L28

Please look at it, and let me know. 

Thanks,
@jeonghanlee 
