### PR TITLE
fix missing cdb python path creation and shebang 

### DIFF
--- a/tools/developer_tools/cdb_plugins/utilities/plugin_manager.py
+++ b/tools/developer_tools/cdb_plugins/utilities/plugin_manager.py
@@ -193,7 +193,12 @@ class PluginManager():
         if os.path.exists(CDB_PYTHON_PLUGIN_PATH):
             # Create a __init__.py file for all python plugins.
             init_file_path = "%s/%s" % (CDB_PYTHON_PLUGIN_PATH, '__init__.py')
-            init_file = os.open(init_file_path, os.O_CREAT)
+            init_file = os.open(init_file_path, os.O_CREAT|os.O_WRONLY)
+            os.write(init_file, "#!/usr/bin/env python\n")
+            os.write(init_file, "\"\"\"\n")
+            os.write(init_file, "Copyright (c) UChicago Argonne, LLC. All rights reserved.\n")
+            os.write(init_file, "See LICENSE file.\n")
+            os.write(init_file, "\"\"\"")
             os.close(init_file)
 
     @staticmethod

--- a/tools/developer_tools/cdb_plugins/utilities/plugin_manager.py
+++ b/tools/developer_tools/cdb_plugins/utilities/plugin_manager.py
@@ -159,6 +159,8 @@ class PluginManager():
             os.mkdir(CDB_JAVA_PLUGIN_PATH)
         if not os.path.exists(CDB_XHTML_PLUGIN_PATH):
             os.makedirs(CDB_XHTML_PLUGIN_PATH)
+        if not os.path.exists(CDB_PYTHON_PLUGIN_PATH):
+            os.makedirs(CDB_PYTHON_PLUGIN_PATH)
         if not os.path.exists(self.cdb_plugin_configuration_storage):
             os.makedirs(self.cdb_plugin_configuration_storage)
 


### PR DESCRIPTION
- The path `${CDB_WEB_SERVICE_CODE_PATH}/cdb_web_service/plugins` is missing, so ` __init__.py` file is not generated due to the following lines:

https://github.com/AdvancedPhotonSource/ComponentDB/blob/3ff7e945e722783a30392095d9c177e60627b79d/tools/developer_tools/cdb_plugins/utilities/plugin_manager.py#L157-L163

- `__init__.py` is an empty file, technically and typically it doesn't matter, but add the shebang to make it consistently. 

I may be wrong, since I am looking deeply into micro code area, please let me know what you think.

@jeonghanlee 