### PR TITLE
allow users to configure DbManager fully with Environment Varaibles

### DIFF
--- a/src/python/cdb/common/utility/configurationManager.py
+++ b/src/python/cdb/common/utility/configurationManager.py
@@ -199,6 +199,9 @@ class ConfigurationManager(UserDict.UserDict):
         self.__setFromEnvVar('sslKeyFile', 'CDB_SSL_KEY_FILE')
 
         self.__setFromEnvVar('configFile', 'CDB_CONFIG_FILE')
+
+        self.__setFromEnvVar('dbSchema', 'CDB_DB_SCHEMA')
+        self.__setFromEnvVar('dbUser', 'CDB_DB_USER')
         self.__setFromEnvVar('dbPasswordFile', 'CDB_DB_PASSWORD_FILE')
 
         # Settings that might come from file.


### PR DESCRIPTION
@iTerminate 

Please look at this pull request, and let me know what you think. 

This request gives users full flexibility in order to configure MySQL / MariaDB database configuration. Thus, two additional DbManager options ( `dbSchema`, `dbUser`) can be configured by (`CDB_DB_SCHEMA`, and `CDB_DB_USER`) in addition with `CDB_DB_PASSWORD_FILE`.

Thanks,
@jeonghanlee 
