### PR TITLE
fixed typo in order to match a usage message with an actual function name

### DIFF
--- a/src/python/cdb/cdb_web_service/cli/deleteLogCli.py
+++ b/src/python/cdb/cdb_web_service/cli/deleteLogCli.py
@@ -23,7 +23,7 @@ class DeleteLogCli(CdbWebServiceSessionCli):
 
     def runCommand(self):
         self.parseArgs(usage="""
-    cdb-update-log --log-id=LOG_ID
+    cdb-delete-log --log-id=LOG_ID
 
 Description:
     Removes a log entry.


### PR DESCRIPTION
@iTerminate 

This request contains a fixed typo in a cdb web service python script.  Please let me know what you think. 

@jeonghanlee 